### PR TITLE
Add missing boilerplate key/value

### DIFF
--- a/boilerplate/ignite.json.ejs
+++ b/boilerplate/ignite.json.ejs
@@ -1,5 +1,6 @@
 {
   "createdWith": "<%= props.igniteVersion %>",
+  "boilerplate": "ignite-ir-boilerplate-andross",
   "examples": "classic",
   "navigation": "react-navigation",
   "askToOverwrite": true


### PR DESCRIPTION
Boilerplate created with `ignite plugin new my-plugin` should have a "boilerplate" key/value.

```
{
  "createdWith": "<%= props.igniteVersion %>",
  "boilerplate": "<%= props.name %>"
}
```
https://github.com/infinitered/ignite/blob/master/src/templates/plugin/boilerplate/ignite/ignite.json
https://github.com/infinitered/ignite/issues/829
https://github.com/infinitered/ignite/issues/1267