### PR TITLE
Security: Upgrade lodash

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -19,7 +19,7 @@
     "apisauce": "^0.14.2",
     "format-json": "^1.0.3",
     "identity-obj-proxy": "^3.0.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.11",
     "prop-types": "^15.6.1",
     "querystringify": "1.0.0",
     "ramda": "^0.25.0",


### PR DESCRIPTION
Per a Github [security alert](https://github.com/infinitered/ignite-ir-boilerplate-andross/network/alert/package-lock.json/lodash/open), this upgrades lodash to the latest version.